### PR TITLE
Update `waterEntropy` Dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.11", "3.12", "3.13"]
     timeout-minutes: 30
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,10 +19,10 @@ classifiers = [
     "Development Status :: 3 - Alpha",
 ]
 keywords = ["water", "entropy", "molecular dynamics", "forces"]
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
-    "mdanalysis==2.9.0",
-    "numpy==1.26.2",
+    "mdanalysis>=2.7.0",
+    "numpy==2.2.3",
 ]
 
 [project.urls]


### PR DESCRIPTION
### Summary
Updated some of the dependencies to ensure they are as up to date as possible.

### Changes:
- Updated the `python` requirements to include the 3 latest versions of `python`: `3.11`, `3.12` and `3.13` 
- Updated the `ci.yaml` to keep consistency of the latest 3 versions of `python`
- Included a range for `mdanalysis`
- Upgdated `numpy` to `v2.2.3`

### Impact:
- This will ensure that `waterEntropy` is as up to date as possible and avoid merge conflicts with other programs