### PR TITLE
29 recipe for bulk water entropy calculation

### DIFF
--- a/tests/recipes/test_interfacial_solvent.py
+++ b/tests/recipes/test_interfacial_solvent.py
@@ -43,9 +43,9 @@ def test_covariances():
         forces,
         np.array(
             [
-                [14436849, 712686, -2141242],
-                [712686, 19792305, 8921010],
-                [-2141242, 8921010, 9880023],
+                [824686, 40711, -122315],
+                [40711, 1130610, 509601],
+                [-122315, 509601, 564383],
             ]
         ),
     )
@@ -53,9 +53,9 @@ def test_covariances():
         torques,
         np.array(
             [
-                [2.89828793e08, 5.06914732e07, -2.92085655e07],
-                [5.06914732e07, 5.83455839e07, -1.13204566e06],
-                [-2.92085655e07, -1.13204566e06, 1.48596049e08],
+                [16556105.19, 2895686.63, -1668502.55],
+                [2895686.63, 3332918.07, -64666.68],
+                [-1668502.55, -64666.68, 8488362.3],
             ]
         ),
     )
@@ -69,12 +69,12 @@ def test_vibrations():
     trans_freqs = vibrations.translational_freq[("ACE_1", "WAT")]
     rot_freqs = vibrations.rotational_freq[("ACE_1", "WAT")]
 
-    assert np.allclose(Strans, np.array([5.59725172, 4.54547502, 6.94449285]))
-    assert np.allclose(Srot, np.array([0.07211633, 1.6609092, 0.37677331]))
-    assert np.allclose(trans_freqs, np.array([[14436849, 19792305, 9880023]]))
-    assert np.allclose(
-        rot_freqs, np.array([[2.89828793e08, 5.83455839e07, 1.48596049e08]])
-    )
+    assert np.allclose(Strans, np.array([16.787066, 15.49228514, 18.34936798]))
+    assert np.allclose(sum(Strans), 50.628719)
+    assert np.allclose(Srot, np.array([5.13190029, 11.11787766, 7.50395398]))
+    assert np.allclose(sum(Srot), 23.75373)
+    assert np.allclose(trans_freqs, np.array([[824686, 1130610, 564383]]))
+    assert np.allclose(rot_freqs, np.array([[16556105, 3332918, 8488362]]))
 
 
 def test_frame_solvent_indices():

--- a/waterEntropy/cli/runWaterEntropy.py
+++ b/waterEntropy/cli/runWaterEntropy.py
@@ -7,10 +7,12 @@ import argparse
 from datetime import datetime
 import logging
 import sys
+import numpy as np
 
 from MDAnalysis import Universe
 
 import waterEntropy.recipes.interfacial_solvent as GetSolvent
+import waterEntropy.recipes.bulk_water as GetBulkSolvent
 import waterEntropy.entropy.vibrations as VIB
 import waterEntropy.entropy.orientations as OR
 
@@ -30,10 +32,13 @@ def run_waterEntropy(
     # load topology and coordinates
     u = Universe(file_topology, file_coords)
 
-    Sorient_dict, covariances, vibrations, frame_solvent_indices = GetSolvent.get_interfacial_water_orient_entropy(u, start, end, step)
+    Sorient_dict, covariances, vibrations, frame_solvent_indices = GetSolvent.get_interfacial_water_orient_entropy(u, start, end, step, temperature=298)
     OR.print_Sorient_dicts(Sorient_dict)
     # GetSolvent.print_frame_solvent_dicts(frame_solvent_indices)
     VIB.print_Svib_data(vibrations, covariances)
+    bulk_Sorient_dict, bulk_covariances, bulk_vibrations = GetBulkSolvent.get_bulk_water_orient_entropy(u, start, end, step, temperature=298)
+    OR.print_Sorient_dicts(bulk_Sorient_dict)
+    VIB.print_Svib_data(bulk_vibrations, bulk_covariances)
 
 
     sys.stdout.flush()
@@ -70,7 +75,7 @@ def main():
             "-s",
             "--start",
             action="store",
-            metavar="int",
+            type=int,
             default=0,
             help="frame number to start analysis from.",
         )
@@ -78,7 +83,7 @@ def main():
             "-e",
             "--end",
             action="store",
-            metavar="int",
+            type=int,
             default=1,
             help="frame number to end analysis at.",
         )
@@ -86,7 +91,7 @@ def main():
             "-dt",
             "--step",
             action="store",
-            metavar="int",
+            type=int,
             default=1,
             help="steps to take between start and end frame selections.",
         )

--- a/waterEntropy/recipes/bulk_water.py
+++ b/waterEntropy/recipes/bulk_water.py
@@ -1,0 +1,89 @@
+"""
+These functions calculate orientational entropy from labelled
+coordination shells of bulk water
+"""
+
+import waterEntropy.analysis.HB as HBond
+import waterEntropy.analysis.HB_labels as HBLabels
+import waterEntropy.analysis.RAD as RADShell
+from waterEntropy.analysis.shells import ShellCollection
+from waterEntropy.entropy.convariances import CovarianceCollection
+from waterEntropy.entropy.orientations import Orientations
+from waterEntropy.entropy.vibrations import Vibrations
+from waterEntropy.recipes.forces_torques import get_forces_torques
+
+
+def get_bulk_water_orient_entropy(
+    system, start: int, end: int, step: int, temperature=298
+):
+    # pylint: disable=too-many-locals
+    """
+    For a given system, containing the topology and coordinates of molecules,
+    find the bulk water and calculate their
+    orientational entropy if there is a solute atom in the solvent coordination
+    shell.
+
+    :param system: mdanalysis instance of atoms in a frame
+    :param start: starting frame number
+    :param end: end frame number
+    :param step: steps between frames
+    """
+    # initialise the Covariance class instance to store covariance matrices
+    covariances = CovarianceCollection()
+    # initialise the Vibrations class instance to store vibrational entropies
+    vibrations = Vibrations(temperature)
+    hb_labels = HBLabels.HBLabelCollection()
+    # pylint: disable=unused-variable
+    for ts in system.trajectory[start:end:step]:
+        # initialise the RAD and HB class instances to store shell information
+        shells = ShellCollection()
+        HBs = HBond.HBCollection()
+        # select all water molecules in the system
+        waters = system.select_atoms("water and mass 2 to 999")
+        # 3. iterate through first shell solvent and find their RAD shells,
+        #   HBing in the shells and shell labels
+        for solvent in waters:
+            # 3a. find RAD shell of interfacial solvent
+            shell = RADShell.get_RAD_shell(solvent, system, shells)
+            # 3b. Set RAD shell labels as resname of neighbour
+            shell.labels = [system.atoms[n].resname for n in shell.UA_shell]
+            # check shell only contains only solvent molecules
+            if set(shell.labels) == {solvent.resname}:
+                # 3c. find HBing in the shell
+                HBond.get_shell_HBs(shell, system, HBs, shells)
+                # 3d. find HB labels
+                HBLabels.get_HB_labels(solvent.index, system, HBs, shells)
+                hb_labels.add_data(
+                    f"{solvent.resname}",
+                    f"{solvent.resname}",
+                    shell.labels,
+                    shell.donates_to_labels,
+                    shell.accepts_from_labels,
+                )
+                # 3e. calculate the running average of force and torque
+                # covariance matrices
+                solvent_molecule = system.atoms[solvent.index].fragment  # get molecule
+                get_forces_torques(
+                    covariances,
+                    solvent_molecule,
+                    f"{solvent.resname}",
+                    system,
+                )
+
+    # 4. get the orientational entropy of interfacial waters and save
+    #   them to a dictionary
+    # TO-DO: add average Nc in Sorient dict
+    # Sorient_dict = Orient.get_resid_orientational_entropy_from_dict(
+    #     hb_labels.resid_labelled_shell_counts
+    # )
+    Sorients = Orientations()
+    Sorients.add_data(hb_labels)
+    Sorient_dict = Sorients.resid_labelled_Sorient
+    # 5. Get the vibrational entropy of interfacial waters
+    vibrations.add_data(covariances, diagonalise=True)
+
+    return (
+        Sorient_dict,
+        covariances,
+        vibrations,
+    )

--- a/waterEntropy/recipes/interfacial_solvent.py
+++ b/waterEntropy/recipes/interfacial_solvent.py
@@ -61,7 +61,9 @@ def find_interfacial_solvent(solutes, system, shells: ShellCollection):
     return list(set(solvent_indices))
 
 
-def get_interfacial_water_orient_entropy(system, start: int, end: int, step: int):
+def get_interfacial_water_orient_entropy(
+    system, start: int, end: int, step: int, temperature=298
+):
     # pylint: disable=too-many-locals
     """
     For a given system, containing the topology and coordinates of molecules,
@@ -79,7 +81,7 @@ def get_interfacial_water_orient_entropy(system, start: int, end: int, step: int
     # initialise the Covariance class instance to store covariance matrices
     covariances = CovarianceCollection()
     # initialise the Vibrations class instance to store vibrational entropies
-    vibrations = Vibrations(temperature=298, force_units="kcal")
+    vibrations = Vibrations(temperature)
     hb_labels = HBLabels.HBLabelCollection()
     # pylint: disable=unused-variable
     for ts in system.trajectory[start:end:step]:


### PR DESCRIPTION
The version of MDAnalysis used in water entropy saves forces as kJ/(mol Ang) by default, so the conversion has been updated to reflect this. This will be a breaking change for previous versions of waterEntropy using previous version of MDAnalysis.