### PR TITLE
Add parallel routine for interfacial water orientational entropy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,8 @@ requires-python = ">=3.11"
 dependencies = [
     "mdanalysis>=2.7.0",
     "numpy==2.2.3",
+    "dask==2025.7.0",
+    "distributed==2025.7.0",
 ]
 
 [project.urls]

--- a/tests/recipes/test_interfacial_solvent_parallel.py
+++ b/tests/recipes/test_interfacial_solvent_parallel.py
@@ -1,0 +1,162 @@
+""" Tests for waterEntropy interfacial solvent functions in neighbours."""
+
+import numpy as np
+import pytest
+
+from tests.input_files import load_inputs
+import waterEntropy.recipes.interfacial_solvent as GetSolvent
+
+# get mda universe for arginine in solution
+system = load_inputs.get_amber_arginine_soln_universe()
+Sorient_dict, covariances, vibrations, frame_solvent_indices = (
+    GetSolvent.parallel_interfacial_water_orient_entropy(system, start=0, end=4, step=2)
+)
+frame_solvent_shells = GetSolvent.get_interfacial_shells(system, start=0, end=4, step=2)
+
+
+def test_frame_solvent_shells():
+    """Test outputted shell indices outputted in frame_solvent_shells dictionary
+    from a first shell solvent"""
+    # frame: {atom_idx: [shell_indices]}
+    assert len(frame_solvent_shells[0].keys()) == 32
+    assert len(frame_solvent_shells[2].keys()) == 36
+    assert frame_solvent_shells[0][1024] == [415, 931, 1318, 1618, 25, 1474, 1282]
+    assert frame_solvent_shells[2][1024] == [1318, 460, 580, 25, 1714, 19, 2497]
+
+
+def test_Sorient_dict():
+    """Test outputted orientational entropy values of solvent molecules around a given solute molecule"""
+    # resid: {resname = [Sorient, count]}
+    assert Sorient_dict[1]["ACE"] == pytest.approx([2.2473807716251804, 13])
+    assert Sorient_dict[2]["ARG"] == pytest.approx([2.6481382191024245, 35])
+    assert Sorient_dict[3]["NME"] == pytest.approx([0.9503950365967891, 12])
+
+
+def test_covariances():
+    "Test the covariance matrices"
+
+    forces = covariances.forces[("ACE_1", "WAT")]
+    torques = covariances.torques[("ACE_1", "WAT")]
+    count = covariances.counts[("ACE_1", "WAT")]
+
+    assert np.allclose(
+        forces,
+        np.array(
+            [
+                [824686, 40711, -122315],
+                [40711, 1130610, 509601],
+                [-122315, 509601, 564383],
+            ]
+        ),
+    )
+    assert np.allclose(
+        torques,
+        np.array(
+            [
+                [16556105.19, 2895686.63, -1668502.55],
+                [2895686.63, 3332918.07, -64666.68],
+                [-1668502.55, -64666.68, 8488362.3],
+            ]
+        ),
+    )
+    assert count == 13
+
+
+def test_vibrations():
+    "Test the vibrational entropies"
+    Strans = vibrations.translational_S[("ACE_1", "WAT")]
+    Srot = vibrations.rotational_S[("ACE_1", "WAT")]
+    trans_freqs = vibrations.translational_freq[("ACE_1", "WAT")]
+    rot_freqs = vibrations.rotational_freq[("ACE_1", "WAT")]
+
+    assert np.allclose(Strans, np.array([16.787066, 15.49228514, 18.34936798]))
+    assert np.allclose(sum(Strans), 50.628719)
+    assert np.allclose(Srot, np.array([5.13190029, 11.11787766, 7.50395398]))
+    assert np.allclose(sum(Srot), 23.75373)
+    assert np.allclose(trans_freqs, np.array([[824686, 1130610, 564383]]))
+    assert np.allclose(rot_freqs, np.array([[16556105, 3332918, 8488362]]))
+
+
+def test_frame_solvent_indices():
+    """Test the get interfacial water orient entropy function"""
+    # frame: {resname: {resid = [shell indices]}}
+    assert frame_solvent_indices[0].get("ACE").get(1) == [
+        121,
+        235,
+        481,
+        505,
+        1639,
+        2260,
+        2314,
+    ]
+    assert frame_solvent_indices[0].get("ARG").get(2) == [
+        55,
+        244,
+        274,
+        862,
+        931,
+        1024,
+        1165,
+        1282,
+        1474,
+        1855,
+        1912,
+        2005,
+        2056,
+        2077,
+        2245,
+        2497,
+    ]
+    assert frame_solvent_indices[0].get("NME").get(3) == [
+        85,
+        205,
+        265,
+        1057,
+        1246,
+        1753,
+    ]
+    assert frame_solvent_indices[0].get("Cl-").get(4) == [460, 1669, 2041]
+    assert frame_solvent_indices[2].get("ACE").get(1) == [
+        505,
+        664,
+        1036,
+        1147,
+        1165,
+        2260,
+    ]
+    assert frame_solvent_indices[2].get("ARG").get(2) == [
+        49,
+        235,
+        274,
+        346,
+        409,
+        475,
+        580,
+        862,
+        931,
+        1024,
+        1048,
+        1228,
+        1855,
+        1858,
+        1891,
+        2056,
+        2404,
+        2497,
+        2605,
+    ]
+    assert frame_solvent_indices[2].get("NME").get(3) == [
+        43,
+        85,
+        205,
+        763,
+        1246,
+        1753,
+    ]
+    assert frame_solvent_indices[2].get("Cl-").get(4) == [
+        460,
+        1669,
+        1945,
+        2005,
+        2041,
+    ]

--- a/tests/recipes/test_interfacial_solvent_parallel.py
+++ b/tests/recipes/test_interfacial_solvent_parallel.py
@@ -11,17 +11,6 @@ system = load_inputs.get_amber_arginine_soln_universe()
 Sorient_dict, covariances, vibrations, frame_solvent_indices = (
     GetSolvent.parallel_interfacial_water_orient_entropy(system, start=0, end=4, step=2)
 )
-frame_solvent_shells = GetSolvent.get_interfacial_shells(system, start=0, end=4, step=2)
-
-
-def test_frame_solvent_shells():
-    """Test outputted shell indices outputted in frame_solvent_shells dictionary
-    from a first shell solvent"""
-    # frame: {atom_idx: [shell_indices]}
-    assert len(frame_solvent_shells[0].keys()) == 32
-    assert len(frame_solvent_shells[2].keys()) == 36
-    assert frame_solvent_shells[0][1024] == [415, 931, 1318, 1618, 25, 1474, 1282]
-    assert frame_solvent_shells[2][1024] == [1318, 460, 580, 25, 1714, 19, 2497]
 
 
 def test_Sorient_dict():

--- a/tests/recipes/test_interfacial_solvent_parallel.py
+++ b/tests/recipes/test_interfacial_solvent_parallel.py
@@ -9,7 +9,9 @@ import waterEntropy.recipes.interfacial_solvent as GetSolvent
 # get mda universe for arginine in solution
 system = load_inputs.get_amber_arginine_soln_universe()
 Sorient_dict, covariances, vibrations, frame_solvent_indices = (
-    GetSolvent.parallel_interfacial_water_orient_entropy(system, start=0, end=4, step=2)
+    GetSolvent.get_interfacial_water_orient_entropy(
+        system, start=0, end=4, step=2, parallel=True
+    )
 )
 
 

--- a/waterEntropy/analysis/HB_labels.py
+++ b/waterEntropy/analysis/HB_labels.py
@@ -150,6 +150,146 @@ class HBLabelCollection:
                     "accepts_from"
                 ][d] += 1
 
+    def merge(self, other):
+        # pylint: disable=too-many-nested-blocks
+        # pylint: disable=too-many-branches
+        """
+        Merge another HBLabelCollection into this one.
+
+        :param other: another HBLabelCollection to merge
+        """
+
+        for resid in other.resid_labelled_shell_counts:
+            for resname in other.resid_labelled_shell_counts[resid]:
+                for labelled_shell in other.resid_labelled_shell_counts[resid][resname]:
+                    for D_A_count_key in other.resid_labelled_shell_counts[resid][
+                        resname
+                    ][labelled_shell]:
+                        if D_A_count_key in ["donates_to", "accepts_from"]:
+                            for DA in other.resid_labelled_shell_counts[resid][resname][
+                                labelled_shell
+                            ][D_A_count_key]:
+                                if (
+                                    DA
+                                    in self.resid_labelled_shell_counts[resid][resname][
+                                        labelled_shell
+                                    ][D_A_count_key]
+                                ):
+                                    self.resid_labelled_shell_counts[resid][resname][
+                                        labelled_shell
+                                    ][D_A_count_key][
+                                        DA
+                                    ] += other.resid_labelled_shell_counts[
+                                        resid
+                                    ][
+                                        resname
+                                    ][
+                                        labelled_shell
+                                    ][
+                                        D_A_count_key
+                                    ][
+                                        DA
+                                    ]
+                                else:
+                                    self.resid_labelled_shell_counts[resid][resname][
+                                        labelled_shell
+                                    ][D_A_count_key][
+                                        DA
+                                    ] = other.resid_labelled_shell_counts[
+                                        resid
+                                    ][
+                                        resname
+                                    ][
+                                        labelled_shell
+                                    ][
+                                        D_A_count_key
+                                    ][
+                                        DA
+                                    ]
+                        else:
+                            # shell_count
+                            if (
+                                D_A_count_key
+                                in self.resid_labelled_shell_counts[resid][resname][
+                                    labelled_shell
+                                ]
+                            ):
+                                self.resid_labelled_shell_counts[resid][resname][
+                                    labelled_shell
+                                ][D_A_count_key] += other.resid_labelled_shell_counts[
+                                    resid
+                                ][
+                                    resname
+                                ][
+                                    labelled_shell
+                                ][
+                                    D_A_count_key
+                                ]
+                            else:
+                                self.resid_labelled_shell_counts[resid][resname][
+                                    labelled_shell
+                                ][D_A_count_key] = other.resid_labelled_shell_counts[
+                                    resid
+                                ][
+                                    resname
+                                ][
+                                    labelled_shell
+                                ][
+                                    D_A_count_key
+                                ]
+
+        for resname in other.labelled_shell_counts:
+            for labelled_shell in other.labelled_shell_counts[resname]:
+                for D_A_count_key in other.labelled_shell_counts[resname][
+                    labelled_shell
+                ]:
+                    if D_A_count_key in ["donates_to", "accepts_from"]:
+                        for DA in other.labelled_shell_counts[resname][labelled_shell][
+                            D_A_count_key
+                        ]:
+                            if (
+                                DA
+                                in self.labelled_shell_counts[resname][labelled_shell][
+                                    D_A_count_key
+                                ]
+                            ):
+                                self.labelled_shell_counts[resname][labelled_shell][
+                                    D_A_count_key
+                                ][DA] += other.labelled_shell_counts[resname][
+                                    labelled_shell
+                                ][
+                                    D_A_count_key
+                                ][
+                                    DA
+                                ]
+                            else:
+                                self.labelled_shell_counts[resname][labelled_shell][
+                                    D_A_count_key
+                                ][DA] = other.labelled_shell_counts[resname][
+                                    labelled_shell
+                                ][
+                                    D_A_count_key
+                                ][
+                                    DA
+                                ]
+                    else:
+                        # shell_count
+                        if (
+                            D_A_count_key
+                            in self.labelled_shell_counts[resname][labelled_shell]
+                        ):
+                            self.labelled_shell_counts[resname][labelled_shell][
+                                D_A_count_key
+                            ] += other.labelled_shell_counts[resname][labelled_shell][
+                                D_A_count_key
+                            ]
+                        else:
+                            self.labelled_shell_counts[resname][labelled_shell][
+                                D_A_count_key
+                            ] = other.labelled_shell_counts[resname][labelled_shell][
+                                D_A_count_key
+                            ]
+
 
 def get_HB_labels(atom_idx: int, system, HBs: HBCollection, shells: ShellCollection):
     """

--- a/waterEntropy/entropy/convariances.py
+++ b/waterEntropy/entropy/convariances.py
@@ -82,3 +82,27 @@ class CovarianceCollection:
             count_dict[(nearest, molecule_name)] = 1
         else:
             count_dict[(nearest, molecule_name)] += 1
+
+    def merge(self, other):
+        """
+        Merge another CovarianceCollection into this one.
+
+        :param other: another CovarianceCollection to merge
+        """
+        for key in other.forces:
+            if key not in self.forces:
+                self.forces[key] = other.forces[key]
+                self.torques[key] = other.torques[key]
+                self.counts[key] = other.counts[key]
+            else:
+                # weighted sum of the forces and torques
+                self.forces[key] = (
+                    self.forces[key] * self.counts[key]
+                    + other.forces[key] * other.counts[key]
+                ) / (self.counts[key] + other.counts[key])
+                self.torques[key] = (
+                    self.torques[key] * self.counts[key]
+                    + other.torques[key] * other.counts[key]
+                ) / (self.counts[key] + other.counts[key])
+                # sum of the counts
+                self.counts[key] += other.counts[key]

--- a/waterEntropy/recipes/interfacial_solvent.py
+++ b/waterEntropy/recipes/interfacial_solvent.py
@@ -205,15 +205,11 @@ def get_interfacial_water_orient_entropy(
     # Steps 1,2 and 3 in function calls.
     if parallel is True:
         covariances, frame_solvent_indices, hb_labels = (
-            _parallel_interfacial_water_orient_entropy(
-                system, start, end, step, temperature, client
-            )
+            _parallel_interfacial_water_orient_entropy(system, start, end, step, client)
         )
     else:
         covariances, frame_solvent_indices, hb_labels = (
-            _serial_interfacial_water_orient_entropy(
-                system, start, end, step, temperature
-            )
+            _serial_interfacial_water_orient_entropy(system, start, end, step)
         )
     # 4. get the orientational entropy of interfacial waters and save
     #   them to a dictionary

--- a/waterEntropy/recipes/interfacial_solvent.py
+++ b/waterEntropy/recipes/interfacial_solvent.py
@@ -3,7 +3,7 @@ These functions calculate orientational entropy from labelled
 coordination shells
 """
 
-from multiprocessing import Pool
+import multiprocessing as mp
 
 import waterEntropy.analysis.HB as HBond
 import waterEntropy.analysis.HB_labels as HBLabels
@@ -159,6 +159,7 @@ def parallel_interfacial_water_orient_entropy(
     :param end: end frame number
     :param step: steps between frames
     """
+    mp.set_start_method("fork")
     # don't need to include the frame_solvent_indices dictionary
     frame_solvent_indices = nested_dict()
     # initialise the Covariance class instance to store covariance matrices
@@ -170,7 +171,7 @@ def parallel_interfacial_water_orient_entropy(
     args = [
         (index, system) for index, _ in enumerate(system.trajectory[start:end:step])
     ]
-    with Pool() as pool:
+    with mp.Pool() as pool:
         results = pool.map(_parallel_interfacial_water_orient_entropy, args)
     # merge the solvent indices dicts
     for res in results:

--- a/waterEntropy/recipes/interfacial_solvent.py
+++ b/waterEntropy/recipes/interfacial_solvent.py
@@ -165,8 +165,9 @@ def parallel_interfacial_water_orient_entropy(
     # parallelise over frames by packing them and vars into generator object.
     # can't seem to use the system.trajectory directly because it appears to
     # give unpredictable results with all the frames being the same!
+    indices = list(range(start, end, step))
     args = [
-        (index, system) for index, _ in enumerate(system.trajectory[start:end:step])
+        (index, system) for index, _ in zip(indices, system.trajectory[start:end:step])
     ]
     with mp.Pool() as pool:
         results = pool.map(_parallel_interfacial_water_orient_entropy, args)


### PR DESCRIPTION
Summary
This PR enable the interfacial orientational entropy calculation to happen in a frame parallelised fashion. Speeding up the execution of the code as a factor of the number of cores available.

Changes
updated pyproject.toml to include required dependencies (dask, distributed)
renamed get_interfacial_water_orient_entropy() to _serial_interfacial_water_orient_entropy
added _parallel_interfacial_water_orient_entropy with parallel logic
added a new get_interfacial_water_orient_entropy() as a common interface to the parallel and serial methods controlled by setting param parallel=True/False
added a _entropy_per_step() helper function with single frame entropy calc logic to be called in parallel executing processes.
added new logic to combine frame data calculated in parallel
added a test for the new parallel code

Impact
This is the first pass on introducing parallelism to the entropy suite of tools, there are many more optimisations that can be applied in future here. The impact of this is that now calculations can be done on larger systems in a reasonable amount of time.