### PR TITLE
38 add number of frames analysed to args

### DIFF
--- a/docs/source/user_guide/index.rst
+++ b/docs/source/user_guide/index.rst
@@ -32,11 +32,13 @@ Here's how to use waterEntropy via the API:
     start, end, step = 0, 4, 2
 
     # Calculate the entropy
-    Sorient_dict, covariances, vibrations, frame_solvent_indices = GetSolvent.get_interfacial_water_orient_entropy(
+    Sorient_dict, covariances, vibrations, frame_solvent_indices, n_frames = GetSolvent.get_interfacial_water_orient_entropy(
         u, start, end, step,
         parallel=False, # option to parallelise the calculate is set to False by default, set True for parallel calculation
         temperature=298, # default simulated system temperate is set to 298 Kelvin, change accordingly
     )
+
+    print(f"Number of frames analysed: {n_frames}")
 
     # Print Sorient
     OR.print_Sorient_dicts(Sorient_dict)

--- a/tests/recipes/test_interfacial_solvent.py
+++ b/tests/recipes/test_interfacial_solvent.py
@@ -10,7 +10,7 @@ import waterEntropy.recipes.interfacial_solvent as GetSolvent
 def serial_interfacial_entropy():
     """Return the entropy dictionaries calcalated via serial process"""
     system = load_inputs.get_amber_arginine_soln_universe()
-    Sorient_dict, covariances, vibrations, frame_solvent_indices = (
+    Sorient_dict, covariances, vibrations, frame_solvent_indices, n_frames = (
         GetSolvent.get_interfacial_water_orient_entropy(system, start=0, end=4, step=2)
     )
     frame_solvent_shells = GetSolvent.get_interfacial_shells(
@@ -21,6 +21,7 @@ def serial_interfacial_entropy():
         covariances,
         vibrations,
         frame_solvent_indices,
+        n_frames,
         frame_solvent_shells,
     )
 
@@ -28,12 +29,12 @@ def serial_interfacial_entropy():
 def parallel_interfacial_entropy():
     """Return the entropy dictionaries calcalated via serial process"""
     system = load_inputs.get_amber_arginine_soln_universe()
-    Sorient_dict, covariances, vibrations, frame_solvent_indices = (
+    Sorient_dict, covariances, vibrations, frame_solvent_indices, n_frames = (
         GetSolvent.get_interfacial_water_orient_entropy(
             system, start=0, end=4, step=2, parallel=True
         )
     )
-    return Sorient_dict, covariances, vibrations, frame_solvent_indices
+    return Sorient_dict, covariances, vibrations, frame_solvent_indices, n_frames
 
 
 INTERFACIAL_ENTROPY_DICTS = pytest.mark.parametrize(
@@ -45,7 +46,7 @@ INTERFACIAL_ENTROPY_DICTS = pytest.mark.parametrize(
 def test_frame_solvent_shells():
     """Test outputted shell indices outputted in frame_solvent_shells dictionary
     from a first shell solvent"""
-    frame_solvent_shells = serial_interfacial_entropy()[4]
+    frame_solvent_shells = serial_interfacial_entropy()[5]
     # frame: {atom_idx: [shell_indices]}
     assert len(frame_solvent_shells[0].keys()) == 32
     assert len(frame_solvent_shells[2].keys()) == 36
@@ -197,3 +198,10 @@ def test_frame_solvent_indices(interfacial_entropy_dicts):
         2005,
         2041,
     ]
+
+
+@INTERFACIAL_ENTROPY_DICTS
+def test_n_frames(interfacial_entropy_dicts):
+    """Test the get interfacial water orient entropy function"""
+    n_frames = interfacial_entropy_dicts[4]
+    assert n_frames == 2

--- a/waterEntropy/cli/runWaterEntropy.py
+++ b/waterEntropy/cli/runWaterEntropy.py
@@ -34,7 +34,8 @@ def run_waterEntropy(
     # load topology and coordinates
     u = Universe(file_topology, file_coords)
     # interfacial waters
-    Sorient_dict, covariances, vibrations, frame_solvent_indices = GetSolvent.get_interfacial_water_orient_entropy(u, start, end, step, temperature, parallel)
+    Sorient_dict, covariances, vibrations, frame_solvent_indices, n_frames = GetSolvent.get_interfacial_water_orient_entropy(u, start, end, step, temperature, parallel)
+    print(f"Number of frames analysed: {n_frames}")
     OR.print_Sorient_dicts(Sorient_dict)
     # GetSolvent.print_frame_solvent_dicts(frame_solvent_indices)
     VIB.print_Svib_data(vibrations, covariances)


### PR DESCRIPTION
The `n_frames` argument has been included as an output from the interfacial water entropy recipe. This allows for the number of frames analysed to be confirmed and be used to calculate the average number of interfacial waters over the number of frames analysed.

A separate PR will focus on improvements in how entropy results are displayed to the user. 