### PR TITLE
Include number of neighbours around interfacial waters in entropy outputs

### DIFF
--- a/tests/recipes/test_bulk_water.py
+++ b/tests/recipes/test_bulk_water.py
@@ -1,0 +1,93 @@
+""" Tests for waterEntropy bulk water functions in neighbours."""
+
+import numpy as np
+import pytest
+
+from tests.input_files import load_inputs
+import waterEntropy.recipes.bulk_water as GetBulk
+
+
+def bulk_water_entropy():
+    """Return the entropy dictionaries calcalated via serial process"""
+    system = load_inputs.get_amber_arginine_soln_universe()
+    Sorient_dict, covariances, vibrations = GetBulk.get_bulk_water_orient_entropy(
+        system, start=0, end=1, step=1
+    )
+    return (
+        Sorient_dict,
+        covariances,
+        vibrations,
+    )
+
+
+BULK_WATER_ENTROPY_DICTS = pytest.mark.parametrize(
+    "bulk_water_entropy_dicts",
+    [bulk_water_entropy()],
+)
+
+
+@BULK_WATER_ENTROPY_DICTS
+def test_Sorient_dict(bulk_water_entropy_dicts):
+    """Test outputted orientational entropy values of solvent molecules around a given solute molecule"""
+    # resid: {resname = [Sorient, count]}
+    Sorient_dict = bulk_water_entropy_dicts[0]
+    print(Sorient_dict)
+    assert Sorient_dict["WAT"]["WAT"] == pytest.approx(
+        [
+            11.295694179188464,
+            867,
+            6.053509907760105,
+            6.053509907760105,
+            6.053509907760105,
+            0.2291068586055006,
+        ]
+    )
+
+
+@BULK_WATER_ENTROPY_DICTS
+def test_covariances(bulk_water_entropy_dicts):
+    """Test the covariance matrices"""
+
+    covariances = bulk_water_entropy_dicts[1]
+    forces = covariances.forces[("WAT", "WAT")]
+    torques = covariances.torques[("WAT", "WAT")]
+    count = covariances.counts[("WAT", "WAT")]
+
+    assert np.allclose(
+        forces,
+        np.array(
+            [
+                [677766.79725371, 57015.33553172, 1713.75817016],
+                [57015.33553172, 1498012.49688953, 37806.43086811],
+                [1713.75817016, 37806.43086811, 951068.82244533],
+            ]
+        ),
+    )
+    assert np.allclose(
+        torques,
+        np.array(
+            [
+                [8.82222234e06, -1.57822726e05, 5.92784745e05],
+                [-1.57822726e05, 6.49223541e06, 6.08836668e03],
+                [5.92784745e05, 6.08836668e03, 1.41024728e07],
+            ]
+        ),
+    )
+    assert count == 867
+
+
+@BULK_WATER_ENTROPY_DICTS
+def test_vibrations(bulk_water_entropy_dicts):
+    "Test the vibrational entropies"
+    vibrations = bulk_water_entropy_dicts[2]
+    Strans = vibrations.translational_S[("WAT", "WAT")]
+    Srot = vibrations.rotational_S[("WAT", "WAT")]
+    trans_freqs = vibrations.translational_freq[("WAT", "WAT")]
+    rot_freqs = vibrations.rotational_freq[("WAT", "WAT")]
+
+    assert np.allclose(Strans, np.array([17.59459292, 14.34269432, 16.2012916]))
+    assert np.allclose(sum(Strans), 48.1385788374531)
+    assert np.allclose(Srot, np.array([7.36084486, 8.51428332, 5.6781004]))
+    assert np.allclose(sum(Srot), 21.553228577722663)
+    assert np.allclose(trans_freqs, np.array([[677766, 1498012, 951068]]))
+    assert np.allclose(rot_freqs, np.array([[8822222, 6492235, 14102472]]))

--- a/tests/recipes/test_bulk_water.py
+++ b/tests/recipes/test_bulk_water.py
@@ -31,7 +31,6 @@ def test_Sorient_dict(bulk_water_entropy_dicts):
     """Test outputted orientational entropy values of solvent molecules around a given solute molecule"""
     # resid: {resname = [Sorient, count]}
     Sorient_dict = bulk_water_entropy_dicts[0]
-    print(Sorient_dict)
     assert Sorient_dict["WAT"]["WAT"] == pytest.approx(
         [
             11.295694179188464,

--- a/tests/recipes/test_interfacial_solvent.py
+++ b/tests/recipes/test_interfacial_solvent.py
@@ -59,9 +59,36 @@ def test_Sorient_dict(interfacial_entropy_dicts):
     """Test outputted orientational entropy values of solvent molecules around a given solute molecule"""
     # resid: {resname = [Sorient, count]}
     Sorient_dict = interfacial_entropy_dicts[0]
-    assert Sorient_dict[1]["ACE"] == pytest.approx([2.2473807716251804, 13])
-    assert Sorient_dict[2]["ARG"] == pytest.approx([2.6481382191024245, 35])
-    assert Sorient_dict[3]["NME"] == pytest.approx([0.9503950365967891, 12])
+    assert Sorient_dict[1]["ACE"] == pytest.approx(
+        [
+            2.2473807716251804,
+            13,
+            6.467857142857143,
+            5.257142857142858,
+            2.9594964080590276,
+            0.10765314493056646,
+        ]
+    )
+    assert Sorient_dict[2]["ARG"] == pytest.approx(
+        [
+            2.6481382191024245,
+            35,
+            7.3085782312925165,
+            5.835721088435374,
+            3.2771824257183773,
+            0.10732165472942556,
+        ]
+    )
+    assert Sorient_dict[3]["NME"] == pytest.approx(
+        [
+            0.9503950365967891,
+            12,
+            6.538461538461538,
+            5.1923076923076925,
+            2.050259026687599,
+            0.07010328362114078,
+        ]
+    )
 
 
 @INTERFACIAL_ENTROPY_DICTS

--- a/waterEntropy/analysis/HB_labels.py
+++ b/waterEntropy/analysis/HB_labels.py
@@ -18,12 +18,13 @@ class HBLabelCollection:
     The counts are placed into two dictionaries used for statistics later,
     the structure of these two dictionaries are as follows:
 
-    dict1 = {"resname": {("labelled_shell"): {"shell_count": 0,
+    dict1 = {"resname": {("labelled_shell"): {"shell_count": 0, "N_w": N_w,
                                 "donates_to": {"labelled_donators": 0,},
                                 "accepts_from": {"labelled_acceptors": 0,}
                                 }}}
     dict2 = {"nearest_resid": {"resname":
                                 {("labelled_shell"): {"shell_count": 0,
+                                "N_w": N_w,
                                 "donates_to": {"labelled_donators": 0,},
                                 "accepts_from": {"labelled_acceptors": 0,}
                                 }}}
@@ -33,14 +34,14 @@ class HBLabelCollection:
         self.labelled_shell_counts = nested_dict()  # save shell instances in here
         self.resid_labelled_shell_counts = nested_dict()  # save shell instances in here
 
-    def add_data(self, resid, resname, labelled_shell, donates_to, accepts_from):
+    def add_data(self, resid, resname, labelled_shell, donates_to, accepts_from, N_w):
         # pylint: disable=too-many-arguments
         """Add data to class dictionaries"""
-        self.add_shell_counts(resid, resname, labelled_shell)
+        self.add_shell_counts(resid, resname, labelled_shell, N_w)
         self.add_donates_to(resid, resname, labelled_shell, donates_to)
         self.add_accepts_from(resid, resname, labelled_shell, accepts_from)
 
-    def add_shell_counts(self, resid, resname, labelled_shell):
+    def add_shell_counts(self, resid, resname, labelled_shell, N_w):
         """
         Add a labelled shell to a dictionary that keeps track of the counts
         for each labelled shell type with constituents alpha-numerically
@@ -54,6 +55,7 @@ class HBLabelCollection:
         labelled_shell = tuple(sorted(labelled_shell))
         if "shell_count" not in self.labelled_shell_counts[resname][labelled_shell]:
             self.labelled_shell_counts[resname][labelled_shell]["shell_count"] = 1
+            self.labelled_shell_counts[resname][labelled_shell]["N_w"] = N_w
         else:
             self.labelled_shell_counts[resname][labelled_shell]["shell_count"] += 1
 
@@ -64,6 +66,9 @@ class HBLabelCollection:
             self.resid_labelled_shell_counts[resid][resname][labelled_shell][
                 "shell_count"
             ] = 1
+            self.resid_labelled_shell_counts[resid][resname][labelled_shell][
+                "N_w"
+            ] = N_w
         else:
             self.resid_labelled_shell_counts[resid][resname][labelled_shell][
                 "shell_count"
@@ -213,7 +218,7 @@ class HBLabelCollection:
                                 in self.resid_labelled_shell_counts[resid][resname][
                                     labelled_shell
                                 ]
-                            ):
+                            ) and D_A_count_key != "N_w":  # N_w = fixed
                                 self.resid_labelled_shell_counts[resid][resname][
                                     labelled_shell
                                 ][D_A_count_key] += other.resid_labelled_shell_counts[
@@ -277,7 +282,7 @@ class HBLabelCollection:
                         if (
                             D_A_count_key
                             in self.labelled_shell_counts[resname][labelled_shell]
-                        ):
+                        ) and D_A_count_key != "N_w":  # N_w = fixed
                             self.labelled_shell_counts[resname][labelled_shell][
                                 D_A_count_key
                             ] += other.labelled_shell_counts[resname][labelled_shell][

--- a/waterEntropy/analysis/shell_labels.py
+++ b/waterEntropy/analysis/shell_labels.py
@@ -34,6 +34,7 @@ def get_shell_labels(atom_idx: int, system, shell, shells: ShellCollection):
     if nearest_nonlike_idx is not None:
         nearest_nonlike = system.atoms[nearest_nonlike_idx]
         shell_labels = []
+        N_w = 0
         for n in shell.UA_shell:
             neighbour = system.atoms[n]
             # 3a. label nearest nonlike atom as "0_RESNAME"
@@ -51,6 +52,7 @@ def get_shell_labels(atom_idx: int, system, shell, shells: ShellCollection):
                 neighbour.index != nearest_nonlike.index
                 and neighbour.resname == center.resname
             ):
+                N_w += 1
                 neighbour_shell = shells.find_shell(neighbour.index)
                 if not neighbour_shell:
                     neighbour_shell = RADShell.get_RAD_shell(neighbour, system, shells)
@@ -81,6 +83,7 @@ def get_shell_labels(atom_idx: int, system, shell, shells: ShellCollection):
                         shell_labels.append(f"X_{neighbour.resname}")
         shell.labels = shell_labels  # sorted(shell_labels) #don't sort yet
         shell.nearest_nonlike_idx = nearest_nonlike.index
+        shell.N_w = N_w
     return shell
 
 

--- a/waterEntropy/analysis/shells.py
+++ b/waterEntropy/analysis/shells.py
@@ -55,6 +55,7 @@ class ShellCollection:
             self.set_property(atom_idx, "labels", None)
             self.set_property(atom_idx, "donates_to_labels", None)
             self.set_property(atom_idx, "accepts_from_labels", None)
+            self.set_property(atom_idx, "N_w", None)
 
     def set_property(self, atom_idx, key: str, value):
         """Set a property for a specific atom shell, ensuring it exists first.

--- a/waterEntropy/entropy/orientations.py
+++ b/waterEntropy/entropy/orientations.py
@@ -3,6 +3,7 @@ Store orientational entropies here
 """
 
 from collections import Counter
+import textwrap
 
 import numpy as np
 
@@ -17,6 +18,8 @@ class WaterOrientCalculator:
 
     def __init__(self):
         self.Sorient = 0
+        self.Nc_eff = 0
+        self.pbias_ave = 0
 
     def add_data(self, shell_label: list, shell_values: dict):
         """
@@ -35,6 +38,8 @@ class WaterOrientCalculator:
             degeneracy, pD_dict, pA_dict
         )
         self.Sorient = self.get_orientation_S(Nc_eff, pbias_ave)
+        self.Nc_eff = Nc_eff
+        self.pbias_ave = pbias_ave
 
     def get_shell_degeneracy(self, shell_label: list):
         """
@@ -234,7 +239,7 @@ class Orientations:
         shell with format:
 
         resid_labelled_dict = {"nearest_resid": {"resname":
-                {("labelled_shell"): {"shell_count": 0,
+                {("labelled_shell"): {"shell_count": 0, "N_w": N_w,
                 "donates_to": {"labelled_donators": 0,},
                 "accepts_from": {"labelled_acceptors": 0,}
                 }}}
@@ -276,6 +281,7 @@ class Orientations:
         shell with format:
 
         labelled_dict = {"resname": {("labelled_shell"): {"shell_count": 0,
+                                    "N_w": N_w,
                                     "donates_to": {"labelled_donators": 0,},
                                     "accepts_from": {"labelled_acceptors": 0,}
                                     }}}
@@ -287,13 +293,35 @@ class Orientations:
         """
         for resname, shell_label_key in sorted(list(labelled_dict.items())):
             Sorient_ave, tot_count = 0, 0
+            N_c_ave, N_w_ave, Nc_eff_ave, pbias_ave = 0, 0, 0, 0
             for shell_label, values in sorted(list(shell_label_key.items())):
                 water = WaterOrientCalculator()
                 water.add_data(shell_label, values)
+                # only update tot_count here
                 Sorient_ave, tot_count = self.get_running_average(
                     water.Sorient, values["shell_count"], Sorient_ave, tot_count
                 )
-            Sorient_dict[resname] = [Sorient_ave, tot_count]
+                # ignore the _tot_count
+                Nc_eff_ave, _tot_count = self.get_running_average(
+                    water.Nc_eff, values["shell_count"], Nc_eff_ave, tot_count
+                )
+                pbias_ave, _tot_count = self.get_running_average(
+                    water.pbias_ave, values["shell_count"], pbias_ave, tot_count
+                )
+                N_c_ave, _tot_count = self.get_running_average(
+                    len(shell_label), values["shell_count"], N_c_ave, tot_count
+                )
+                N_w_ave, _tot_count = self.get_running_average(
+                    values["N_w"], values["shell_count"], N_w_ave, tot_count
+                )
+            Sorient_dict[resname] = [
+                Sorient_ave,
+                tot_count,
+                N_c_ave,
+                N_w_ave,
+                Nc_eff_ave,
+                pbias_ave,
+            ]
 
 
 def print_Sorient_dicts(Sorient_dict: dict):
@@ -302,6 +330,29 @@ def print_Sorient_dicts(Sorient_dict: dict):
 
     :param Sorient_dict: dictionary containing orientational entropy values
     """
+    terms = """
+    Orientations
+    ============
+    resid: residue ID of the closest solute to the waters
+    resname: name of the residue associated with the residue ID
+    Sor: Orientational entropy of water around residue
+    count: total number of waters around the residue across frames analysed
+    N_c: average number of UAs around waters analysed
+    N_w: average number of water UAs around waters analysed
+    Nc_eff: average number of effective neighbouts that waters can HB with
+    pbias: average of the probability of forming HBs with neighbouring UAs
+    """
+    print(textwrap.dedent(terms))
+
+    print("resid resname Sor count N_c N_w Nc_eff pbias")
     for resid, resname_key in sorted(list(Sorient_dict.items())):
-        for resname, [Sor, count] in sorted(list(resname_key.items())):
-            print(resid, resname, Sor, count)
+        for resname, [Sor, count, N_c, N_w, Nc_eff, pbias] in sorted(
+            list(resname_key.items())
+        ):
+            decimals = 4
+            print(
+                f"{resid} {resname} {Sor:.{decimals}f} {count} "
+                f"{N_c:.{decimals}f} {N_w:.{decimals}f} "
+                f"{Nc_eff:.{decimals}f} {pbias:.{decimals}f}"
+            )
+    print()

--- a/waterEntropy/entropy/vibrations.py
+++ b/waterEntropy/entropy/vibrations.py
@@ -2,6 +2,8 @@
 Store vibrational entropy from covariance matrices
 """
 
+import textwrap
+
 import numpy as np
 from numpy import linalg as LA
 
@@ -197,15 +199,34 @@ def print_Svib_data(vibrations: Vibrations, covariances: CovarianceCollection):
     :param vibrations: instance of Vibrations class
     :param covariances: instance of CovarianceCollection class
     """
+    terms = """
+    Vibrations
+    ==========
+    resid: residue ID of the closest solute to the waters
+    resname: name of the residue associated with the residue ID
+    solvent_name: name of the solvent near the solute
+    Strans: sum of 3 translational terms to give total translational entropy
+    Srot: sum of 3 rotational terms to give total rotational entropy
+    Svib: vibrational entropy (Strans+Srot) of water molecules
+    counts: total number of waters around the nearest solute across frames analysed
+    """
+    print(textwrap.dedent(terms))
+    print("resid resname solvent_name Strans Srot Svib counts")
+    decimals = 4
     for near_solvent_name, Strans in vibrations.translational_S.items():
-        near = near_solvent_name[0]
+        resname, resid = near_solvent_name[0].split("_")
         solvent_name = near_solvent_name[1]
         # forces = covariances.forces[near_solvent_name]
         # torques = covariances.torques[near_solvent_name]
         Strans = vibrations.translational_S[near_solvent_name]
         Srot = vibrations.rotational_S[near_solvent_name]
+        Svib = sum(Strans) + sum(Srot)
         # trans_freqs = vibrations.translational_freq[near_solvent_name]
         # rot_freqs = vibrations.rotational_freq[near_solvent_name]
         counts = covariances.counts[near_solvent_name]
-        print(near, solvent_name, Strans, Srot, counts)
-        print(near, solvent_name, sum(Strans), sum(Srot), counts)
+        # print(near, solvent_name, Strans, Srot, counts)
+        print(
+            f"{resid} {resname} {solvent_name} {sum(Strans):.{decimals}f} "
+            f"{sum(Srot):.{decimals}f} {Svib:.{decimals}f} {counts}"
+        )
+    print()

--- a/waterEntropy/entropy/vibrations.py
+++ b/waterEntropy/entropy/vibrations.py
@@ -214,7 +214,10 @@ def print_Svib_data(vibrations: Vibrations, covariances: CovarianceCollection):
     print("resid resname solvent_name Strans Srot Svib counts")
     decimals = 4
     for near_solvent_name, Strans in vibrations.translational_S.items():
-        resname, resid = near_solvent_name[0].split("_")
+        if "_" in near_solvent_name[0]:
+            resname, resid = near_solvent_name[0].split("_")
+        else:
+            resname, resid = near_solvent_name[0], "N/A"
         solvent_name = near_solvent_name[1]
         # forces = covariances.forces[near_solvent_name]
         # torques = covariances.torques[near_solvent_name]

--- a/waterEntropy/recipes/bulk_water.py
+++ b/waterEntropy/recipes/bulk_water.py
@@ -59,7 +59,7 @@ def get_bulk_water_orient_entropy(
                     shell.labels,
                     shell.donates_to_labels,
                     shell.accepts_from_labels,
-                    shell.N_w,
+                    len(shell.labels),  # set N_w
                 )
                 # 3e. calculate the running average of force and torque
                 # covariance matrices

--- a/waterEntropy/recipes/bulk_water.py
+++ b/waterEntropy/recipes/bulk_water.py
@@ -59,6 +59,7 @@ def get_bulk_water_orient_entropy(
                     shell.labels,
                     shell.donates_to_labels,
                     shell.accepts_from_labels,
+                    shell.N_w,
                 )
                 # 3e. calculate the running average of force and torque
                 # covariance matrices

--- a/waterEntropy/recipes/interfacial_solvent.py
+++ b/waterEntropy/recipes/interfacial_solvent.py
@@ -118,7 +118,6 @@ def get_interfacial_shells(system, start: int, end: int, step: int):
     frame_solvent_shells = nested_dict()
     # pylint: disable=unused-variable
     for ts in system.trajectory[start:end:step]:
-        # print(ts)
         # initialise the RAD and HB class instances to store shell information
         shells = ShellCollection()
         # 1. find > 1 UA molecules in system, these are the solutes
@@ -305,7 +304,6 @@ def _entropy_per_step(args):
     # 7. iterate through first shell solvent and find their RAD shells,
     #   HBing in the shells and shell labels
     for solvent in first_shell_solvent:
-        # print(solvent)
         # 8a. find RAD shell of interfacial solvent
         shell = RADShell.get_RAD_shell(solvent, system, shells)
         # 8b. find HBing in the shell
@@ -326,6 +324,7 @@ def _entropy_per_step(args):
                 shell.labels,
                 shell.donates_to_labels,
                 shell.accepts_from_labels,
+                shell.N_w,
             )
             frame_solvent_indices = save_solvent_indices(
                 ts.frame,


### PR DESCRIPTION
1. Following terms are included in the orientational entropy outputs: 

- N_c: average number of UAs around waters analysed
- N_w: average number of water UAs around waters analysed
- Nc_eff: average number of effective neighbouts that waters can HB with
- pbias: average of the probability of forming HBs with neighbouring UAs

2. Vibrational entropy output is tidied 
3. Test includes additional terms in orientational entropy dictionary

