### PR TITLE
Update release tooling to Flit 4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,11 +121,11 @@ jobs:
     - name: install flit
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flit~=3.9
+        python -m pip install "flit>=4,<5" "flit_core>=4,<5"
 
     - name: build and publish
       run: |
-        flit publish
+        flit publish --use-vcs
       env:
         FLIT_USERNAME: __token__
         FLIT_PASSWORD:  ${{ secrets.pypi_token }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 # build the package with [flit](https://flit.readthedocs.io)
-requires = ["flit_core >=3.4,<4"]
+requires = ["flit_core >=4,<5"]
 build-backend = "flit_core.buildapi"
 
 [project]


### PR DESCRIPTION
## Summary
This PR updates the repository to use Flit 4 consistently across the build and release configuration, preventing incompatible Flit and `flit_core` major versions from being resolved during publishing.

## Changes
### Flit configuration:
* Updated `flit_core` build requirements to `>=4,<5`.
* Updated the release workflow to install `flit>=4,<5` and `flit_core>=4,<5`.
* Updated `flit publish` to use `--use-vcs`.

## Impact
* Keeps the build and publishing environments on compatible Flit major versions.
* Fixes release failures caused by Flit 3 resolving against Flit Core 4.
* Prevents future major `flit_core` versions from being pulled into the current release configuration unexpectedly.
* Preserves the existing source distribution behaviour when publishing with Flit 4.